### PR TITLE
feat: add supoort for custom lighthouse config

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,20 @@
                     "report": true
                 }
             ]
+        },
+        {
+            "url": "https://www.example.com",
+            "plugins": [
+                {
+                    "name": "lighthouse",
+                    "report": true,
+                    "config": {
+                        "settings": {
+                            "emulatedFormFactor": "desktop"
+                        }
+                    }
+                }
+            ]
         }
     ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,12 @@ services:
       - INFLUXDB_ADMIN_USER=admin
       - INFLUXDB_ADMIN_PASSWORD=admin
   garie-lighthouse:
-    image: "garie-lighthouse:latest"
+    build: "."
     volumes:
       - ./reports:/usr/src/garie-lighthouse/reports
     ports:
       - 3000:3000
     environment:
       - HOST=influxdb  
+    depends_on:
+      - influxdb

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "garie-lighthouse",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "description": "Lighthouse image for performance metrics",
     "license": "MIT",
     "repository": "boyney123/garie-lighthouse",

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ async function getDataForAllUrls() {
                 await saveReport(url, raw);
             }
         } catch (err) {
-            console.error(err);
+            console.log(err);
         }
     }
 
@@ -60,13 +60,13 @@ async function main () {
             );
         }
     } catch (err) {
-        console.error(err);
+        console.log(err);
     }
 };
 
 if (process.env.ENV !== 'test') {
     app.listen(3000, async () => {
-        console.info('Application listening on port 3000');
+        console.log('Application listening on port 3000');
         await main();
     });
 }

--- a/src/light-house/utils.js
+++ b/src/light-house/utils.js
@@ -7,7 +7,6 @@ const chromeFlags = [
 	'--headless',
 	'--no-zygote',
 	'--no-sandbox',
-	'--headless',
 ];
 
 const launchChromeAndRunLighthouse = async (url, config) => {


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
Add the ability to customize lighthouse config per URL, like this:
```js
{
            "url": "https://www.example.com",
            "plugins": [
                {
                    "name": "lighthouse",
                    "report": true,
                    "config": {
                        "settings": {
                            "emulatedFormFactor": "desktop"
                        }
                    }
                }
            ]
        }
```


<!-- Why are these changes necessary? -->

**Why**:
I want lighthouse to check the benchmark for desktop only webapp, and unfortuantly it's crashing with the current config.

<!-- How were these changes implemented? -->

**How**:

via URL based custom config

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
