### PR TITLE
closes #5: Use dumb-init as entrypoint to avoid zombie processes issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,13 @@ RUN \
     apt-get update && \
     apt-get install -y google-chrome-stable
 
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb
+RUN dpkg -i dumb-init_*.deb
+
 COPY . .
 
 EXPOSE 3000
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 CMD ["npm", "start"]


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Avoid zombie chrome and cat processes 

<!-- Why are these changes necessary? -->

**Why**: Stability

<!-- How were these changes implemented? -->

**How**:  Modifying Dockerfile

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
