### PR TITLE
Add ability to pass custom Lighthouse config object

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,17 +148,19 @@ _By default, reports on webhook's are not generated unless you set `report` to t
 | `plugins`        | `object` (optional)  | To setup custom lighthouse config.                        |
 | `plugins.name`   | `string` (required)  | Needs to be set to `lighthouse`                           |
 | `plugins.report` | `boolean` (optional) | If set to true, lighthouse report will also be generated. |
-| `plugins.config` | `object` (optional)  | To configure lighthouse, such as device type and throttling. See [Configuration](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) for details |
+| `plugins.config` | `object` (optional)  | To configure lighthouse, such as device type and throttling. See [Configuration](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) for details. |
 
 ## Example (Basic Config)
 
 ```javascript
 {
 	"url": "https://www.bbc.co.uk",
-	"plugins": [{
-		"name": "lighthouse",
-		"report": true
-	}]
+	"plugins": [
+		{
+			"name": "lighthouse",
+			"report": true
+		}
+	]
 }
 ```
 
@@ -166,15 +168,17 @@ _By default, reports on webhook's are not generated unless you set `report` to t
 ```javascript
 {
 	"url": "https://www.bbc.co.uk",
-	"plugins": [{
-		"name": "lighthouse",
-		"report": true,
-		"config": {
-			"extends": "lighthouse:default",
-			"settings": {
-				"emulatedFormFactor": "desktop"
+	"plugins": [
+		{
+			"name": "lighthouse",
+			"report": true,
+			"config": {
+				"extends": "lighthouse:default",
+				"settings": {
+					"emulatedFormFactor": "desktop"
+				}
 			}
 		}
-	}]
+	]
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -148,17 +148,33 @@ _By default, reports on webhook's are not generated unless you set `report` to t
 | `plugins`        | `object` (optional)  | To setup custom lighthouse config.                        |
 | `plugins.name`   | `string` (required)  | Needs to be set to `lighthouse`                           |
 | `plugins.report` | `boolean` (optional) | If set to true, lighthouse report will also be generated. |
+| `plugins.config` | `object` (optional)  | To configure lighthouse, such as device type and throttling. See [Configuration](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) for details |
 
-## Example
+## Example (Basic Config)
 
 ```javascript
 {
-  "url": "https://www.bbc.co.uk",
-  "plugins": [
-	  {
-		  "name": "lighthouse",
-		  "report": true
-	  }
-  ]
+	"url": "https://www.bbc.co.uk",
+	"plugins": [{
+		"name": "lighthouse",
+		"report": true
+	}]
+}
+```
+
+## Example (Custom Config)
+```javascript
+{
+	"url": "https://www.bbc.co.uk",
+	"plugins": [{
+		"name": "lighthouse",
+		"report": true,
+		"config": {
+			"extends": "lighthouse:default",
+			"settings": {
+				"emulatedFormFactor": "desktop"
+			}
+		}
+	}]
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -29,9 +29,9 @@ const getDataForAllUrls = async () => {
                 return name === 'lighthouse';
             });
 
-            const { report } = pluginConfig || {};
+            const { report, config } = pluginConfig || {};
 
-            const { raw, filteredData } = (await getData(item.url)) || {};
+            const { raw, filteredData } = (await getData(item.url, config)) || {};
 
             await saveData(item.url, filteredData);
 

--- a/src/light-house/index.js
+++ b/src/light-house/index.js
@@ -47,15 +47,12 @@ const filterResults = (data = {}) => {
 const fs = require('fs');
 
 module.exports = {
-    getData: async (url, report = {}) => {
+    getData: async (url, config = {}) => {
         try {
             logger.info(`Getting data for ${url}`);
 
             const lighthouse =
-                (await launchChromeAndRunLighthouse(url, {
-                    extends: 'lighthouse:default'
-                    // Can add other things here, to throttle connections (Maybe maybe differnt connect types and report on them in the long run)
-                })) || {};
+                (await launchChromeAndRunLighthouse(url, { extends: 'lighthouse:default', ...config })) || {};
 
             logger.info(`Successfully got data for ${url}`);
 

--- a/src/light-house/spec.js
+++ b/src/light-house/spec.js
@@ -29,6 +29,11 @@ describe('reporter', () => {
             expect(launchChromeAndRunLighthouse).toBeCalledWith(URL, { extends: 'lighthouse:default' });
         });
 
+        it('opens chrome and runs lighthouse with the given url and custom lighthouse configuration', () => {
+            getData(URL, { settings: { emulatedFormFactor: 'desktop '}});
+            expect(launchChromeAndRunLighthouse).toBeCalledWith(URL, { extends: 'lighthouse:default', settings: { emulatedFormFactor: 'desktop '}});
+        });
+
         it('returns filtered data when successfully getting data from lighthouse', async () => {
             launchChromeAndRunLighthouse.mockResolvedValue(mockData);
 


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Added ability to pass in a `config` object into the lighthouse plugin which directly maps to the object you would pass to the `lighthouse` module. 

**Why**:

Currently `garie-lighthouse` uses the default preset configuration for running audits, which is an emulated mobile device with some level of throttling. However, it would be beneficial to be able to audit as a desktop device and with varying levels of throttling. 

**How**:

You can add the following inside `urls` in `config.json`.

```javascript
"url": "https://www.google.com",
"plugins": [
    {
        "name": "lighthouse",
        "report": true,
        "config": {
            "extends": "lighthouse:default",
            "settings": {
                "emulatedFormFactor": "desktop"
            }
        }
    }
]
```

There are many other configurations one could use as referenced [here](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md).

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

Regarding tests, I've added one simple test to assert that the config is passed through correctly to the Lighthouse API, but I don't think it's necessary to test the data that comes back otherwise we are testing their code.

By the way, there are no contributing guidelines and no table to add myself.