### PR TITLE
Adding ability to add custom labels to Lighthouse tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,12 +142,12 @@ _By default, reports on webhook's are not generated unless you set `report` to t
 
 **urls object**
 
-| Property         | Type                 | Description                                               |
-| ---------------- | -------------------- | --------------------------------------------------------- |
-| `url`            | `string` (required)  | Url to get lighthouse metrics for.                        |
-| `plugins`        | `object` (optional)  | To setup custom lighthouse config.                        |
-| `plugins.name`   | `string` (required)  | Needs to be set to `lighthouse`                           |
-| `plugins.report` | `boolean` (optional) | If set to true, lighthouse report will also be generated. |
+| Property         | Type                 | Description                                                                                                                                                                 |
+| ---------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`            | `string` (required)  | Url to get lighthouse metrics for.                                                                                                                                          |
+| `plugins`        | `object` (optional)  | To setup custom lighthouse config.                                                                                                                                          |
+| `plugins.name`   | `string` (required)  | Needs to be set to `lighthouse`                                                                                                                                             |
+| `plugins.report` | `boolean` (optional) | If set to true, lighthouse report will also be generated.                                                                                                                   |
 | `plugins.config` | `object` (optional)  | To configure lighthouse, such as device type and throttling. See [Configuration](https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md) for details. |
 
 ## Example (Basic Config)
@@ -178,6 +178,26 @@ _By default, reports on webhook's are not generated unless you set `report` to t
 					"emulatedFormFactor": "desktop"
 				}
 			}
+		}
+	]
+}
+```
+
+## Example (Custom Config With Label)
+```javascript
+{
+	"url": "https://www.bbc.co.uk",
+	"plugins": [
+		{
+			"name": "lighthouse",
+			"report": true,
+			"config": {
+				"extends": "lighthouse:default",
+				"settings": {
+					"emulatedFormFactor": "desktop"
+				}
+			},
+			"label": "desktop"
 		}
 	]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,10 @@ const getDataForAllUrls = async () => {
 
             const { raw, filteredData } = (await getData(item.url, config)) || {};
 
-            await saveData(item.url, label, filteredData);
+            await saveData(item.url, filteredData, label);
 
             if (report) {
-                await saveReport(url, label, raw);
+                await saveReport(url, raw, label);
             }
         } catch (err) {
             console.log(err);

--- a/src/index.js
+++ b/src/index.js
@@ -29,14 +29,14 @@ const getDataForAllUrls = async () => {
                 return name === 'lighthouse';
             });
 
-            const { report, config } = pluginConfig || {};
+            const { report, config, label } = pluginConfig || {};
 
             const { raw, filteredData } = (await getData(item.url, config)) || {};
 
-            await saveData(item.url, filteredData);
+            await saveData(item.url, label, filteredData);
 
             if (report) {
-                await saveReport(url, raw);
+                await saveReport(url, label, raw);
             }
         } catch (err) {
             console.log(err);

--- a/src/influx/index.js
+++ b/src/influx/index.js
@@ -25,15 +25,15 @@ const init = async () => {
  * @param {String} url - Url from the peroformance data to save
  * @param {*} data - Data to save
  */
-const saveData = async (url, data) => {
+const saveData = async (url, label, data) => {
 
 	try {
-
+		const tag = label ? `${url}~${label}` : url;
 		const points = Object.keys(data).reduce((points, key) => {
 			if (data[key]) {
 				points.push({
 					measurement: key,
-					tags: { url },
+					tags: { tag },
 					fields: { value: data[key] }
 				})
 			}

--- a/src/influx/index.js
+++ b/src/influx/index.js
@@ -25,7 +25,7 @@ const init = async () => {
  * @param {String} url - Url from the peroformance data to save
  * @param {*} data - Data to save
  */
-const saveData = async (url, label, data) => {
+const saveData = async (url, data, label) => {
 
 	try {
 		const tag = label ? `${url}~${label}` : url;

--- a/src/influx/index.js
+++ b/src/influx/index.js
@@ -1,23 +1,22 @@
-const influx = require('./influx');
-const logger = require('../utils/logger');
+const influx = require("./influx");
+const logger = require("../utils/logger");
 
 /**
  * Bootstrap the database
  */
 const init = async () => {
-	try {
-		const names = await influx.getDatabaseNames();
-		if (names.indexOf('lighthouse') === -1) {
-			logger.info('InfluxDB: lighthouse database does not exist. Creating database');
-			return influx.createDatabase('lighthouse');
-			logger.info('InfluxDB: lighthouse database created');
-		}
-		logger.info('InfluxDB', 'lighthouse database already exists. Skipping creation.');
-		return Promise.resolve();
-	} catch (err) {
-		return Promise.reject('Failed to initialise influx')
-	}
-
+  try {
+    const names = await influx.getDatabaseNames();
+    if (names.indexOf("lighthouse") === -1) {
+      logger.info("InfluxDB: lighthouse database does not exist. Creating database");
+      return influx.createDatabase("lighthouse");
+      logger.info("InfluxDB: lighthouse database created");
+    }
+    logger.info("InfluxDB", "lighthouse database already exists. Skipping creation.");
+    return Promise.resolve();
+  } catch (err) {
+    return Promise.reject("Failed to initialise influx");
+  }
 };
 
 /**
@@ -26,33 +25,29 @@ const init = async () => {
  * @param {*} data - Data to save
  */
 const saveData = async (url, data, label) => {
+  try {
+    const tag = label ? `${url}~${label}` : url;
+    const points = Object.keys(data).reduce((points, key) => {
+      if (data[key]) {
+        points.push({
+          measurement: key,
+          tags: { url: tag },
+          fields: { value: data[key] }
+        });
+      }
+      return points;
+    }, []);
 
-	try {
-		const tag = label ? `${url}~${label}` : url;
-		const points = Object.keys(data).reduce((points, key) => {
-			if (data[key]) {
-				points.push({
-					measurement: key,
-					tags: { tag },
-					fields: { value: data[key] }
-				})
-			}
-			return points;
-		}, []);
-
-
-		const result = await influx.writePoints(points);
-		logger.info(`Successfully saved lighthouse data for ${url}`)
-		return result;
-
-	} catch (err) {
-		logger.error(`Failed to save lighthouse data for ${url}`, err)
-	}
-
-}
+    const result = await influx.writePoints(points);
+    logger.info(`Successfully saved lighthouse data for ${url}`);
+    return result;
+  } catch (err) {
+    logger.error(`Failed to save lighthouse data for ${url}`, err);
+  }
+};
 
 module.exports = {
-	influx,
-	init,
-	saveData
+  influx,
+  init,
+  saveData
 };

--- a/src/influx/spec.js
+++ b/src/influx/spec.js
@@ -82,6 +82,36 @@ describe('influxdb', () => {
 
         });
 
+        it('writes influxdb points into the database for each property on a given object if it has values using the label when provided', async () => {
+
+            const label = 'desktop';
+            const url = 'https://www.test.com';
+            const result = await saveData(url, { firstname: 'bob', lastname: 'bob' }, label);
+
+            expect(influx.writePoints).toHaveBeenCalledWith([
+                {
+                    "measurement": "firstname",
+                    "tags": {
+                        "url": `${url}~${label}`
+                    },
+                    "fields": {
+                        "value": "bob"
+                    }
+                },
+                {
+                    "measurement": "lastname",
+                    "tags": {
+                        "url": `${url}~${label}`
+                    },
+                    "fields": {
+                        "value": "bob"
+                    }
+                }
+            ]);
+
+
+        });
+
         it('does not write influxdb points into the database for any property that does not have a value', async () => {
 
             await saveData('https://www.test.com', { firstname: 'bob', lastname: undefined });

--- a/src/utils/save-report/index.js
+++ b/src/utils/save-report/index.js
@@ -3,11 +3,12 @@ const path = require('path');
 const logger = require('../../utils/logger');
 const { generateReport } = require('../../light-house');
 
-module.exports = async (url, data) => {
+module.exports = async (url, label, data) => {
     try {
         const report = await generateReport(url, data);
         const date = new Date();
-        return fs.outputFile(path.join(__dirname, '../../../reports', url.replace(/(^\w+:|^)\/\//, ''), `${new Date().toISOString()}.html`), report);
+        const labelPostfix = label ? `~${label}` : '';
+        return fs.outputFile(path.join(__dirname, '../../../reports', url.replace(/(^\w+:|^)\/\//, ''), `${date.toISOString()}${labelPostfix}.html`), report);
     } catch (err) {
         logger.error(`Failed to generate report for ${url}`, err);
         return Promise.reject('Failed to generate report');

--- a/src/utils/save-report/index.js
+++ b/src/utils/save-report/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const logger = require('../../utils/logger');
 const { generateReport } = require('../../light-house');
 
-module.exports = async (url, label, data) => {
+module.exports = async (url, data, label) => {
     try {
         const report = await generateReport(url, data);
         const date = new Date();

--- a/src/utils/save-report/spec.js
+++ b/src/utils/save-report/spec.js
@@ -37,6 +37,25 @@ describe('save-report', () => {
 
     });
 
+    it('generates a light house report and save it to disk when generateReport is successful with correct label when provided', async () => {
+
+        const today = new Date();
+        const label = 'desktop';
+
+        generateReport.mockResolvedValue(`<html></html>`);
+
+        await saveReport('https://www.save-report-test.co.uk', mockData.lhr, label);
+
+        const filesInFolder = fs.readdirSync(path.join(__dirname, '../../../reports/www.save-report-test.co.uk'));
+
+        const fileMatch = new Date().toISOString().match(/[^T]*/);
+
+        expect(filesInFolder).toHaveLength(1);
+        expect(filesInFolder[0].indexOf(fileMatch[0]) > -1).toEqual(true);
+        expect(filesInFolder[0].indexOf(label) > -1).toEqual(true);
+
+    });
+
     it('throws an error if generating the lighthouse report fails', async () => {
 
         const today = new Date();


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Added ability to label Lighthouse report and data points.

<!-- Why are these changes necessary? -->

**Why**: This can be used to differentiate between reports for same URL made with different Lighthouse plugin confg, for example "desktop" and "mobile". There is no provision to do so in the current setup as reports are saved with the timestamp only and data is added to the database with URL being the only label.

<!-- How were these changes implemented? -->

**How**: I added a parameter called "label" to each Lighthouse config. It's then passed to the functions that save reports and add the data to InfluxDB. If there is no label data is stored in the same format as previously. Otherwise it's stored with ~label added to the end of both filename and the URL for InfluxDB data.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ x ] Documentation
- [ x ] Tests
- [ x ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ N/A ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->